### PR TITLE
fixed split-request to allow single day queries.

### DIFF
--- a/pybaseball/utils.py
+++ b/pybaseball/utils.py
@@ -76,7 +76,7 @@ def split_request(start_dt, end_dt, player_id, url):
     player_id = str(player_id)
     print('Gathering Player Data')
     # break query into multiple requests
-    while current_dt < end_dt:
+    while current_dt <= end_dt:
         remaining = end_dt - current_dt
         # increment date ranges by at most 60 days
         delta = min(remaining, datetime.timedelta(days=2190))


### PR DESCRIPTION
I was having a problem pulling single day statcast queries, for example statcast_pitcher(start_dt =  '2020-08-17', player_id = 12345)

in split_request I changed 
while current_dt = end_dt:
to
while current_dt <= end_dt: 

and successfully tested with the statcast functions.